### PR TITLE
Fix/sign out

### DIFF
--- a/Source/IdleMasterExtended/frmMain.cs
+++ b/Source/IdleMasterExtended/frmMain.cs
@@ -740,6 +740,8 @@ namespace IdleMasterExtended
             Settings.Default.sessionid = string.Empty;
             Settings.Default.steamLogin = string.Empty;
             Settings.Default.steamLoginSecure = string.Empty;
+            Settings.Default.steamMachineAuth = string.Empty;
+            Settings.Default.steamRememberLogin = string.Empty;
             Settings.Default.myProfileURL = string.Empty;
             Settings.Default.steamparental = string.Empty;
             Settings.Default.Save();


### PR DESCRIPTION
## Description
- Clears the application configuration file of cookie values: 
  - `steamMachineAuth`
  - `steamRememberLogin`
- Suppress `WebBrowser` from reusing cookies stored in Internet Explorer:
  - `INTERNET_OPTION_SUPPRESS_BEHAVIOR`
  - `INTERNET_SUPPRESS_COOKIE_PERSIST`
- Updates the browser `User Agent` field with:
  - `Windows NT 10.0` from the previous `Windows NT 6.1`

## Issues
Should help with issues pointing towards the logout not working (cookies were reused by the browser): 
- #261
- #247
- #184
- #183

