### PR TITLE
Fixing strings.pt-BR.resx wrong word

### DIFF
--- a/Source/IdleMasterExtended/localization/strings.pt-BR.resx
+++ b/Source/IdleMasterExtended/localization/strings.pt-BR.resx
@@ -136,7 +136,7 @@
     <value>Atualmente em jogo</value>
   </data>
   <data name="exit" xml:space="preserve">
-    <value>S&amp;Sair</value>
+    <value>&amp;Sair</value>
   </data>
   <data name="file" xml:space="preserve">
     <value>&amp;Arquivo</value>


### PR DESCRIPTION
The "Sair" word had a duplicated "S"