### PR TITLE
Post build: create Languages directory and move language files into it

### DIFF
--- a/Source/IdleMasterExtended/IdleMasterExtended.csproj
+++ b/Source/IdleMasterExtended/IdleMasterExtended.csproj
@@ -334,7 +334,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy /y /d "$(SolutionDir)..\steam-idle Source\steam-idle\bin\Release\steam-idle.exe" "$(TargetDir)"
-xcopy /y /d "$(SolutionDir)..\Dependencies\steam_api64.dll" "$(TargetDir)"</PostBuildEvent>
+xcopy /y /d "$(SolutionDir)..\Dependencies\steam_api64.dll" "$(TargetDir)"
+
+mkdir "$(TargetDir)Languages"
+for /f %25%25x IN ('dir /B /AD $(TargetDir)') do move "$(TargetDir)%25%25x" "$(TargetDir)Languages"
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/IdleMasterExtended/IdleMasterExtended.csproj
+++ b/Source/IdleMasterExtended/IdleMasterExtended.csproj
@@ -333,11 +333,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y /d "$(SolutionDir)..\steam-idle Source\steam-idle\bin\Release\steam-idle.exe" "$(TargetDir)"
-xcopy /y /d "$(SolutionDir)..\Dependencies\steam_api64.dll" "$(TargetDir)"
+    <PostBuildEvent>XCOPY /Y /D "$(SolutionDir)..\steam-idle Source\steam-idle\bin\Release\steam-idle.exe" "$(TargetDir)"
+XCOPY /Y /D "$(SolutionDir)..\Dependencies\steam_api64.dll" "$(TargetDir)"
 
-mkdir "$(TargetDir)Languages"
-for /f %25%25x IN ('dir /B /AD $(TargetDir)') do move "$(TargetDir)%25%25x" "$(TargetDir)Languages"
+RMDIR /S /Q "$(TargetDir)Languages"
+MKDIR "$(TargetDir)Languages"
+FOR /F %25%25X IN ('DIR /B /AD $(TargetDir)') DO IF /I NOT "%25%25X"=="Languages" MOVE /Y "$(TargetDir)%25%25X" "$(TargetDir)Languages"
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Post-build script to automatically create the Languages folder on a successful build.

It reduces the manual work to create a full release.